### PR TITLE
fix error "empty test name must be omitted"

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -794,6 +794,6 @@ pub const WasiInstance = opaque {
     extern "c" fn wasm_instance_delete(?*WasiInstance) void;
 };
 
-test "" {
+test "run_tests" {
     testing.refAllDecls(@This());
 }


### PR DESCRIPTION
When I used wasm-zig as a dependency for wasmtime-zig with zig master (`0.10.0-dev.3602+df507edff`) I ran into the following issue:

```
...
git github.com/zigwasm/wasm-zig                                 3a96556d [######################################] 100%
/Users/cvoigt/go/src/github.com/voigt/wasmtime-zig/.gyro/wasm-zig-zigwasm-github.com-3a96556d/pkg/src/main.zig:797:6: error: empty test name must be omitted
test "" {
     ^~
error: wasmtime-zig...
...
```

Giving the test a name resolved the issue.